### PR TITLE
Add declaration for 'cast' variable

### DIFF
--- a/app/services/cast-receiver-manager/cast-receiver-manager.service.ts
+++ b/app/services/cast-receiver-manager/cast-receiver-manager.service.ts
@@ -1,4 +1,5 @@
 import {Injectable} from 'angular2/core';
+declare let cast;
 
 @Injectable()
 export class CastReceiverManagerService {


### PR DESCRIPTION
My typescript compiler was failing on references to the 'cast' variable. This line solved the problem for me.